### PR TITLE
Workflow publiziert Docker Image zu GitHub Packages und Docker Hub

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,69 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+env:
+  DOCKER_HUB_REGISTRY: docker.io
+  GITHUB_REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_HUB_REGISTRY }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GITHUB_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.GITHUB_REGISTRY }}/${{ github.repository }}
+            ${{ env.DOCKER_HUB_REGISTRY }}/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha
+
+      - name: Print labels and tags
+        run: |
+          echo "Labels: ${{ steps.meta.outputs.labels }}"
+          echo "Tags: ${{ steps.meta.outputs.tags }}"
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Update repo description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ${{ github.repository }}
+          short-description: ${{ github.event.repository.description }}


### PR DESCRIPTION
This commit adds a new workflow file, `publish-docker-image.yml`, which automates the process of building and pushing a Docker image to both Docker Hub and GitHub Container Registry. The workflow is triggered on a release event or manually through the workflow dispatch event. It uses the `docker/build-push-action` and `docker/metadata-action` actions to build the image, extract metadata, and push it with the appropriate tags and labels.

This workflow will make it easier for developers to publish Docker images and ensure consistent tagging and labeling.