### PR TITLE
Release Drafter Workflow wird beim manuellen Starten nicht mehr auf `skipped`gesetzt

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
     runs-on: ubuntu-latest
 
     env:
@@ -39,7 +39,7 @@ jobs:
           echo "Running tests..."
 
   release_draft:
-    if: github.event.pull_request.merged == true
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
     runs-on: ubuntu-latest
     needs: build
 


### PR DESCRIPTION
This commit updates the `.github/workflows/draft_release.yml` file to include the `workflow_dispatch` event in the condition for running the `build` and `release_draft` jobs. This allows the workflow to be manually triggered through the GitHub Actions UI, in addition to being triggered by a merged pull request.

This change improves the flexibility and usability of the workflow, making it easier for developers to trigger the build and release process when needed.