### PR TITLE
Dockerfile Basis-Image auf `python:3.13-rc-alpine3.19` aktualisiert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Verwende ein offizielles Python-Image als Basis
-FROM python:3.13.0b1-alpine3.19
+FROM python:3.13-rc-alpine3.19
 
 # Setze das Arbeitsverzeichnis im Container
 WORKDIR /usr/src/app


### PR DESCRIPTION
Das Dockerfile wurde aktualisiert, um das Basis-Image auf python:3.13-rc-alpine3.19 zu ändern, um die Stabilität und Kompatibilität zu verbessern.