### PR TITLE
Konfigurations-Update für bessere Hierarchie

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -26,8 +26,9 @@ template: |
 
 # Vorlage für jede Änderung (Pull Request), einschließlich Beschreibung.
 change-template: |
-  - $TITLE (@$AUTHOR) [#$NUMBER]
-    $BODY
+  ### $TITLE (@$AUTHOR) [#$NUMBER]
+  
+  $BODY
 
 # Version-Resolver bestimmt die Art der Versionserhöhung basierend auf den PR Labels.
 version-resolver:


### PR DESCRIPTION
Die Titel der PRs werden auf Hierarchieebene 3 gesetzt, während die Details der PRs direkt eingefügt werden, maximal auf Hierarchieebene 4, um eine klare Struktur zu gewährleisten.