### PR TITLE
Konfigurations-Update für spezifische PRs

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -30,6 +30,10 @@ change-template: |
   
   $BODY
 
+# PRs mit diesen Labels aus den Release Notes ausschließen
+exclude-labels:
+  - 'ignore-in-release-notes'
+
 # Version-Resolver bestimmt die Art der Versionserhöhung basierend auf den PR Labels.
 version-resolver:
   major:


### PR DESCRIPTION
Pull Requests mit dem Label ignore-in-release-notes werden aus den Release Notes ausgeschlossen, um die Übersichtlichkeit zu verbessern.