### PR TITLE
Workflow-Update für PR-Änderungen

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -2,7 +2,11 @@ name: Draft Release
 
 on:
   pull_request:
-    types: [closed]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
Release Drafter wird jetzt bei Änderungen an PRs ausgelöst, um sicherzustellen, dass die Release Notes immer aktuell sind. Relevante Ereignisse wie opened, reopened, synchronize, und edited wurden hinzugefügt.