### PR TITLE
Begrüßungsnachrichten für weitere Shells hinzugefügt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,18 @@ COPY scripts/ ./scripts/
 # Stelle sicher, dass die Skripte ausführbar sind
 RUN chmod +x scripts/*.py
 
-# Erstelle eine .profile Datei mit dem Startbefehl
+# Erstelle die Profildateien mit den Startbefehlen
 RUN echo 'echo "Willkommen zu den S3 Restore Utilities!"' >> ~/.profile && \
-    echo 'python3 /usr/src/app/scripts/start.py' >> ~/.profile
+    echo 'python3 /usr/src/app/scripts/start.py' >> ~/.profile && \
+    echo 'echo "Willkommen zu den S3 Restore Utilities!"' >> ~/.bashrc && \
+    echo 'python3 /usr/src/app/scripts/start.py' >> ~/.bashrc && \
+    echo 'echo "Willkommen zu den S3 Restore Utilities!"' >> ~/.zshrc && \
+    echo 'python3 /usr/src/app/scripts/start.py' >> ~/.zshrc && \
+    echo 'echo "Willkommen zu den S3 Restore Utilities!"' >> ~/.shrc && \
+    echo 'python3 /usr/src/app/scripts/start.py' >> ~/.shrc
+
+# Verlinke die .shrc in .profile, um sicherzustellen, dass die Einstellungen geladen werden
+RUN echo 'if [ -f ~/.shrc ]; then . ~/.shrc; fi' >> ~/.profile
 
 # Starte das Startskript und öffne danach eine Shell
-ENTRYPOINT ["sh", "-c", "python3 /usr/src/app/scripts/start.py && exec sh"]
+ENTRYPOINT ["sh", "-c", "echo 'Willkommen zu den S3 Restore Utilities!' && python3 /usr/src/app/scripts/start.py && exec sh"]


### PR DESCRIPTION
- Begrüßungsnachrichten und der Startbefehl für das `start.py`-Skript wurden den Profildateien `.bashrc`, `.zshrc` und `.shrc` hinzugefügt.
- Die bisher vorhandene `.profile`-Datei wurde beibehalten und entsprechend angepasst.

Vorteile:
- Einheitliche Benutzererfahrung durch Begrüßungsnachrichten in verschiedenen Shells.
- Das Startmenü wird nun in allen gängigen Shells angezeigt.