### PR TITLE
Release Drafter Workflow wurde nicht automatisch ausgeführt 

### DIFF
--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -2,11 +2,7 @@ name: Draft Release
 
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - edited
+    types: [closed]
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
Die Triggers für den Workflow wurden vereinfacht damit der Release Drafter-Workflow bei beim geschlossenen Pull Request zuverlässig geschlossen wird.