### PR TITLE
Docker Compose ist Synology-ready

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: Dockerfile
     container_name: s3-restore-utilities
     volumes:
-      - ./downloads:/usr/src/app/downloads
-      - ./logs:/usr/src/app/logs
+      - /volume1/docker/s3-restore-utilities/downloads:/usr/src/app/downloads
+      - /volume1/docker/s3-restore-utilities/logs:/usr/src/app/logs
     env_file:
       - .env
     tty: true


### PR DESCRIPTION
Die `docker-compose.yml` hat zwei vorgeschlagene Volume-Pfade, die der empfohlenen Verzeichnisstruktur von Synology NAS entspricht. Mit dieser Datei kann also sofort ohne Änderung auf Docker Compose umgestiegen werden.

#### Docker Compose Datei:
```yaml
version: '3.8'

services:
  s3-restore-utilities:
    build:
      context: .
      dockerfile: Dockerfile
    container_name: s3-restore-utilities
    volumes:
      - /volume1/docker/s3-restore-utilities/downloads:/usr/src/app/downloads
      - /volume1/docker/s3-restore-utilities/logs:/usr/src/app/logs
    env_file:
      - .env
    tty: true
    stdin_open: true

volumes:
  downloads:
  logs:
```